### PR TITLE
feature/versioning

### DIFF
--- a/src/Authentication.php
+++ b/src/Authentication.php
@@ -137,11 +137,20 @@ class Authentication implements AuthenticationInterface
             'expires_in',
             'access_token',
             'refresh_token',
-            'user',
-            'api_version'
+            'user'
         ];
 
-        return $auth && array_keys($auth) === $matchingKeys;
+        if (!$auth) {
+            return false;
+        }
+
+        foreach ($matchingKeys as $key) {
+            if (!array_key_exists($key, $auth)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
 }


### PR DESCRIPTION
Changes the validation rules to avoid using array_keys() === $matching as the response may contain extra keys, such as api_version, and this is to do with Authentication, so it makes sense authentication related keys should be looked for only