### PR TITLE
Update dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "illuminate/support": "^9.0",
         "illuminate/session": "^9.0",
         "illuminate/pagination": "^9.0",
-        "mblsolutions/inspireddeck-php": "^1.5"
+        "mblsolutions/inspireddeck-php": "^1.5|^2.0"
     },
     "require-dev": {
         "orchestra/testbench": "^7.0",

--- a/composer.json
+++ b/composer.json
@@ -12,15 +12,15 @@
     ],
     "require": {
         "ext-json": "*",
-        "illuminate/routing": "~5.6.0|~5.7.0|~5.8.0|^6.0|^7.0|^8.0|^9.0",
-        "illuminate/support": "~5.6.0|~5.7.0|~5.8.0|^6.0|^7.0|^8.0|^9.0",
-        "illuminate/session": "~5.6.0|~5.7.0|~5.8.0|^6.0|^7.0|^8.0|^9.0",
-        "illuminate/pagination": "~5.6.0|~5.7.0|~5.8.0|^6.0|^7.0|^8.0|^9.0",
+        "illuminate/routing": "^9.0",
+        "illuminate/support": "^9.0",
+        "illuminate/session": "^9.0",
+        "illuminate/pagination": "^9.0",
         "mblsolutions/inspireddeck-php": "^1.5"
     },
     "require-dev": {
-        "orchestra/testbench": "^4.0",
-        "phpunit/phpunit": "^8.0"
+        "orchestra/testbench": "^7.0",
+        "phpunit/phpunit": "^9.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
         }
     ],
     "require": {
+        "php": "^8.0",
         "ext-json": "*",
         "illuminate/routing": "^9.0",
         "illuminate/support": "^9.0",

--- a/src/InspiredDeckServiceProvider.php
+++ b/src/InspiredDeckServiceProvider.php
@@ -2,7 +2,6 @@
 
 namespace MBLSolutions\InspiredDeckLaravel;
 
-use Throwable;
 use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
@@ -63,11 +62,11 @@ class InspiredDeckServiceProvider extends ServiceProvider
      * Inspired Deck Exception Handling
      *
      * @param $request
-     * @param Throwable $exception
+     * @param $exception
      * @param callable|null $function
      * @return JsonResponse|RedirectResponse
      */
-    public static function exceptionHandling($request, Throwable $exception, callable $function = null)
+    public static function exceptionHandling($request, $exception, callable $function = null)
     {
         if (route_contains('async') || route_contains('api')) {
             if ($exception instanceof ValidationException) {

--- a/src/InspiredDeckServiceProvider.php
+++ b/src/InspiredDeckServiceProvider.php
@@ -2,7 +2,7 @@
 
 namespace MBLSolutions\InspiredDeckLaravel;
 
-use Exception;
+use Throwable;
 use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
@@ -63,11 +63,11 @@ class InspiredDeckServiceProvider extends ServiceProvider
      * Inspired Deck Exception Handling
      *
      * @param $request
-     * @param Exception $exception
+     * @param Throwable $exception
      * @param callable|null $function
      * @return JsonResponse|RedirectResponse
      */
-    public static function exceptionHandling($request, Exception $exception, callable $function = null)
+    public static function exceptionHandling($request, Throwable $exception, callable $function = null)
     {
         if (route_contains('async') || route_contains('api')) {
             if ($exception instanceof ValidationException) {


### PR DESCRIPTION
Removing support for older versions of laravel and allowing for newer inspiredeck dependency versions. Should have major bump in version (v2.x) to avoid issues with current live site.